### PR TITLE
Update SRC_URI for ejabberd ebuilds

### DIFF
--- a/net-im/ejabberd/ejabberd-19.08.ebuild
+++ b/net-im/ejabberd/ejabberd-19.08.ebuild
@@ -9,7 +9,7 @@ inherit eutils pam rebar ssl-cert systemd
 
 DESCRIPTION="Robust, scalable and extensible XMPP server"
 HOMEPAGE="https://www.ejabberd.im/ https://github.com/processone/ejabberd/"
-SRC_URI="https://www.process-one.net/downloads/${PN}/${PV}/${P}.tgz
+SRC_URI="https://static.process-one.net/${PN}/downloads/${PV}/${P}.tgz
 	-> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-im/ejabberd/ejabberd-19.09.1.ebuild
+++ b/net-im/ejabberd/ejabberd-19.09.1.ebuild
@@ -9,7 +9,7 @@ inherit eutils pam rebar ssl-cert systemd
 
 DESCRIPTION="Robust, scalable and extensible XMPP server"
 HOMEPAGE="https://www.ejabberd.im/ https://github.com/processone/ejabberd/"
-SRC_URI="https://www.process-one.net/downloads/${PN}/${PV}/${P}.tgz
+SRC_URI="https://static.process-one.net/${PN}/downloads/${PV}/${P}.tgz
 	-> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-im/ejabberd/ejabberd-20.02.ebuild
+++ b/net-im/ejabberd/ejabberd-20.02.ebuild
@@ -9,7 +9,7 @@ inherit eutils pam rebar ssl-cert systemd
 
 DESCRIPTION="Robust, scalable and extensible XMPP server"
 HOMEPAGE="https://www.ejabberd.im/ https://github.com/processone/ejabberd/"
-SRC_URI="https://www.process-one.net/downloads/${PN}/${PV}/${P}.tgz
+SRC_URI="https://static.process-one.net/${PN}/downloads/${PV}/${P}.tgz
 	-> ${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Thanks for providing an ebuild for current versions of ejabberd! While trying to install 20.02 on my server, I discovered that Process One has changed the download locations and the old urls just return 404 now.